### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
     # Push docker image to Docker Hub
     - name: Push Docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: nahueloyha/sr-tp
         username: nahueloyha


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore